### PR TITLE
Rewrite triton ir and clear cache

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,3 +35,13 @@ model.print_kernel_code(0)
 
 # 保存所有产物信息
 model.save_artifacts_info("my_model_artifacts.json")
+
+# 读取 pre_fusion IR 内容
+ir_content = model._decorator_instance.read_ir("ir_pre_fusion")
+if ir_content:
+    print("Pre-fusion IR 内容:\n", ir_content[:300])
+
+# 改写 pre_fusion IR（示例：加一行注释）
+def add_comment_to_ir(content):
+    return "# Modified by script\n" + content if content else content
+model._decorator_instance.rewrite_ir("ir_pre_fusion", add_comment_to_ir)

--- a/torchforge/cachemonitor.py
+++ b/torchforge/cachemonitor.py
@@ -74,6 +74,38 @@ class CacheMonitor:
         """Stop monitoring the cache directory."""
         self.monitoring = False
 
+    def clear_cache(self):
+        """删除cache目录下的所有文件和子目录"""
+        if self.cache_dir.exists():
+            for item in self.cache_dir.iterdir():
+                if item.is_file():
+                    item.unlink()
+                elif item.is_dir():
+                    for sub in item.rglob("*"):
+                        if sub.is_file():
+                            sub.unlink()
+                        elif sub.is_dir():
+                            sub.rmdir()
+                    item.rmdir()
+
+    def read_ir_file(self, ir_type: str = "ir_pre_fusion") -> Optional[str]:
+        """读取指定类型的IR文件内容（如 pre_fusion/post_fusion）"""
+        ir_files = list(self.cache_dir.glob(f"*{ir_type}*"))
+        if ir_files:
+            return self._safe_read_text(ir_files[0])
+        return None
+
+    def rewrite_ir_file(self, ir_type: str = "ir_pre_fusion", rewrite_fn=None) -> bool:
+        """对指定类型的IR文件内容进行改写，rewrite_fn为内容处理函数"""
+        ir_files = list(self.cache_dir.glob(f"*{ir_type}*"))
+        if ir_files and rewrite_fn:
+            content = self._safe_read_text(ir_files[0])
+            new_content = rewrite_fn(content)
+            with open(ir_files[0], 'w', encoding='utf-8') as f:
+                f.write(new_content)
+            return True
+        return False
+
 
 
 

--- a/torchforge/decorate.py
+++ b/torchforge/decorate.py
@@ -10,6 +10,7 @@ class TorchCompilerDecorator:
     def __init__(self, config: Optional[CompileConfig] = None):
         self.config = config or CompileConfig()
         self.cache_monitor =CacheMonitor(self.config.cache_dir)
+        self.cache_monitor.clear_cache()  # 每次初始化都清理cache
         self._setup_environment()
 
     def _setup_environment(self):
@@ -45,6 +46,14 @@ class TorchCompilerDecorator:
         """获取编译过程中生成的文件和信息"""
         return self.cache_monitor.get_generated_files()
     
+    def read_ir(self, ir_type: str = "ir_pre_fusion") -> Optional[str]:
+        """读取指定类型的IR文件内容"""
+        return self.cache_monitor.read_ir_file(ir_type)
+
+    def rewrite_ir(self, ir_type: str = "ir_pre_fusion", rewrite_fn=None) -> bool:
+        """对指定类型的IR文件内容进行改写"""
+        return self.cache_monitor.rewrite_ir_file(ir_type, rewrite_fn)
+
 _default_decorator = TorchCompilerDecorator()
 
 def no_bubble(cls_or_config=None):


### PR DESCRIPTION
Add functionality to read and rewrite Triton intermediate IR files and automatically clear the cache directory on each run.